### PR TITLE
fix: add int casting when check pulp_webserver_worker_processes

### DIFF
--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -17,7 +17,7 @@ pulp_user_home: '/var/lib/pulp'
 pulp_webserver_num_cpu: 10
 pulp_webserver_worker_processes: "{{ pulp_webserver_num_cpu*2|int }}"
 pulp_webserver_worker_connection: "{{ pulp_webserver_num_cpu*1024|int }}"
-pulp_webserver_worker_rlimit_nofile: "{{ pulp_webserver_worker_connection*2|int }}"
+pulp_webserver_worker_rlimit_nofile: "{{ pulp_webserver_worker_connection|int*2|int }}"
 
 # The "static" dir is used by Pulp 2, and has conflicting SELinux policies.
 # https://pulp.plan.io/issues/5995

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -8,7 +8,7 @@ user nginx nginx;
 worker_processes {{ pulp_webserver_worker_processes }}; # 2 * num_cpu
 
 events {
-    {% if  pulp_webserver_worker_processes > 1 %}
+    {% if pulp_webserver_worker_processes|int > 1 %}
     worker_connections {{ pulp_webserver_worker_connection }};  # 1024 * num_cpu
     accept_mutex on;
     {% else %}


### PR DESCRIPTION
in order to avoid this:
'>' not supported between instances of 'str' and 'int'

we need to convert it to int first