### PR TITLE
use inventory_hostname instead of ansible_fqdn

### DIFF
--- a/playbooks/example-use/group_vars/all
+++ b/playbooks/example-use/group_vars/all
@@ -15,4 +15,4 @@ pulp_install_plugins:
   pulp-rpm: {}
 pulp_settings:
   secret_key: secret
-  content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}"
+  content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ inventory_hostname }}"

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -39,7 +39,7 @@ __pulp_common_pulp_settings_defaults:
   private_key_path: "{{ pulp_certs_dir }}/token_private_key.pem"
   public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
   static_url: "{{ (pulp_install_plugins_normalized['galaxy-ng'] is defined) | ternary('/static/', '/assets/') }}"
-  token_server: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_facts.fqdn }}/token/"
+  token_server: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ inventory_hostname }}/token/"
   token_signature_algorithm: ES256
   working_directory: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}/tmp"
   content_path_prefix: "/pulp/content/"


### PR DESCRIPTION
when using the default gathered `ansible_fqdn` we get `rack00-server00` instead of `rack00-server00.lab.lightbitslabs.com`
we need to change the inventory targets to use the full name, e.g `rack00-server00.lab.lightbitslabs.com`

issue: LBM1-37043

deployment link: https://awx01:8043/#/jobs/playbook/5810/output
https://rack05-server90-vm02.lab.lightbitslabs.com/pulp/content/

settings:
```
root@rack05-server90-vm02:~# cat /etc/pulp/settings.py

# Do NOT edit this file. It may be subject of change when PULP is updated.
# Put new or overridden settings in /etc/pulp/settings.local.py instead.
DATABASES = {'default': {'HOST': 'localhost', 'ENGINE': 'django.db.backends.postgresql', 'NAME': 'pulp', 'USER': 'pulp', 'PASSWORD': 'pulp'}}
DB_ENCRYPTION_KEY = '/etc/pulp/certs/database_fields.symmetric.key'
DEPLOY_ROOT = '/storage'
REDIS_HOST = 'localhost'
REDIS_PORT = 6379
CACHE_ENABLED = True
MEDIA_ROOT = '/storage/media'
PRIVATE_KEY_PATH = '/etc/pulp/certs/token_private_key.pem'
PUBLIC_KEY_PATH = '/etc/pulp/certs/token_public_key.pem'
STATIC_URL = '/assets/'
TOKEN_SERVER = 'https://rack05-server90-vm02.lab.lightbitslabs.com/token/'
TOKEN_SIGNATURE_ALGORITHM = 'ES256'
WORKING_DIRECTORY = '/storage/tmp'
CONTENT_PATH_PREFIX = '/pulp/content/'
FILE_UPLOAD_TEMP_DIR = '/storage/tmp'
STATIC_ROOT = '/storage/assets'
SECRET_KEY = 'secret'
CONTENT_ORIGIN = 'https://rack05-server90-vm02.lab.lightbitslabs.com'
```